### PR TITLE
Rename sequera to seqera + add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Hugo build output + cache
+public/
+resources/
+.hugo_build.lock
+
+# Screenshot raw captures (per docs plan — unannotated originals stay local)
+screenshots/raw/

--- a/content/docs/apgap_ecosystem/seqera.md
+++ b/content/docs/apgap_ecosystem/seqera.md
@@ -2,6 +2,7 @@
 title = 'APGAP and Seqera Platform — A Primer'
 date = 2026-04-07T07:07:07+01:00
 weight = 4
+aliases = ['/docs/apgap_ecosystem/sequera/']
 +++
 
 # APGAP and Seqera Platform — A Primer


### PR DESCRIPTION
Renames `content/docs/apgap_ecosystem/sequera.md` -> `seqera.md` per Glen's ask (correct Seqera Platform spelling). Hugo alias in the new file's front matter serves the old URL as a redirect so no inbound links break.

Adds a standard Hugo `.gitignore` (`public/`, `resources/`, `.hugo_build.lock`, `screenshots/raw/`) since the repo didn't have one.

First of several docs PRs. Next up: `prerequisites.md` + `notebook-templates/` catalog page (Phase 1 of the docs plan).