### PR TITLE
Add before-you-begin, notebook templates catalog, Nextflow caching reference

### DIFF
--- a/content/docs/apgap_ecosystem/_index.md
+++ b/content/docs/apgap_ecosystem/_index.md
@@ -5,16 +5,10 @@ weight = 2
 bookCollapseSection = true
 +++
 
-# APGAP Ecoysystem
+# APGAP Ecosystem
 
+APGAP integrates with two industry-leading tools, Seqera Platform and Vertex Workbench, to create a potent environment that facilitates genomic analysis workflows and exploratory data analysis.
 
-This section will provide a comprehensive overview of how our platform integrates industry-leading tools to streamline scientific discovery and data orchestration.
+Seqera Platform is a framework and orchestration engine that ensures complex bioinformatics pipelines are reproducible, resumable, scalable, and portable across any cloud or on-premise infrastructure with Nextflow installed.
 
-Central to our ecosystem is the synergy between APGAP, Seqera and Vertex:
-
-Seqera: Leveraging the power of Nextflow, Seqera serves as our primary orchestration engine. It ensures that complex bioinformatics pipelines are reproducible, scalable, and portable across any cloud or on-premises infrastructure.
-
-Vertex: By integrating with Vertex (including Vertex AI), APGAP incorporates advanced machine learning capabilities and intelligent data modeling, as well as the Jupyter Lab environment allowing users to run Python and R analysis on their data. This allows for deep insights, automated tax and procurement logic (where applicable), and AI-driven analysis of genomic datasets.
-
-Together, these components form a unified environment designed to bridge the gap between raw data and actionable scientific breakthroughs.
-
+Vertex Workbench provides a Jupyter Lab environment with built-in GCS bucket access so users can quickly and easily run Python and R analyses on their data.

--- a/content/docs/apgap_ecosystem/nextflow-caching-and-resuming.md
+++ b/content/docs/apgap_ecosystem/nextflow-caching-and-resuming.md
@@ -1,0 +1,34 @@
++++
+title = 'Nextflow caching and resuming'
+weight = 8
+date = 2026-08-18
++++
+
+# Nextflow caching and resuming
+
+Curated pointers to the canonical Nextflow and Seqera documentation on task caching, resume behavior, and the moving parts that decide when a re-run reuses previous work versus starts from scratch. Useful anytime you launch a pipeline on APGAP, whether through a notebook or through the Seqera Platform Launchpad.
+
+## Nextflow engine
+
+Primary reference: [Caching and resuming (Seqera Nextflow docs)](https://docs.seqera.io/nextflow/cache-and-resume)
+
+| Section | Direct link | What it covers |
+| --- | --- | --- |
+| Task hash | [#task-hash](https://docs.seqera.io/nextflow/cache-and-resume#task-hash) | The exact hash inputs: session ID, task name, container, modules, Conda/Spack, inputs, script, `ext`, bundled `bin/` scripts, stub flag. Where the "safe to change vs. invalidates" split comes from. |
+| Work directory | [#work-directory](https://docs.seqera.io/nextflow/cache-and-resume#work-directory) | Each task gets a unique dir keyed by its hash; Nextflow stages inputs and script in and writes outputs there. Both the storage that gets billed and the reason a new hash means a new dir. |
+| Cache stores | [#cache-stores](https://docs.seqera.io/nextflow/cache-and-resume#cache-stores) | Local `.nextflow/cache` vs. cloud cache, and `NXF_CLOUDCACHE_PATH` for transient cloud VMs. |
+| Troubleshooting → Modified inputs | [#modified-inputs](https://docs.seqera.io/nextflow/cache-and-resume#modified-inputs) | The invalidation list, plus the input-file hash being path + mtime + size. |
+| Troubleshooting → Inconsistent file attributes | [#inconsistent-file-attributes](https://docs.seqera.io/nextflow/cache-and-resume#inconsistent-file-attributes) | NFS/timestamp cache busting and the `cache 'lenient'` fix. |
+| Troubleshooting → Resume not enabled | [#resume-not-enabled](https://docs.seqera.io/nextflow/cache-and-resume#resume-not-enabled) | Why a plain re-run without `-resume` re-executes everything. |
+| Tips → Resuming from a specific run | [#resuming-from-a-specific-run](https://docs.seqera.io/nextflow/cache-and-resume#resuming-from-a-specific-run) | `-resume` reuses the previous session by default; pass a session ID to resume an earlier run. |
+| Tips → Comparing the hashes of two runs | [#comparing-the-hashes-of-two-runs](https://docs.seqera.io/nextflow/cache-and-resume#comparing-the-hashes-of-two-runs) | The `-dump-hashes json` diff recipe for finding exactly what moved a hash. |
+
+## Seqera Platform and supporting pages
+
+| Page | What it covers |
+| --- | --- |
+| [Platform: Nextflow cache and resume](https://docs.seqera.io/platform-cloud/launch/cache-resume) | The Resume vs. Relaunch distinction on the Platform. Relaunch runs from scratch with edited parameters and is only available for Platform-launched runs; Resume uses Nextflow's resume to reuse completed tasks and execute only failed and pending ones. |
+| [Nextflow: `cache` directive](https://docs.seqera.io/nextflow/reference/process#cache) | `cache 'lenient'` and `cache false` semantics. |
+| [Nextflow: `clean` command](https://docs.seqera.io/nextflow/reference/cli/clean) | Deleting work dirs and cache entries for specific runs. |
+| [Seqera blog: Get started on Google Batch](https://seqera.io/blog/nextflow-with-gbatch/) | The plain statement behind the storage question: the workDir is where Nextflow stages input data and stores intermediate and final data. |
+| [Nextflow: Google Cloud executor](https://nextflow.io/docs/latest/google.html) | `workDir` must be a bucket subdirectory; Fusion configuration. |

--- a/content/docs/apgap_ecosystem/notebook-templates/_index.md
+++ b/content/docs/apgap_ecosystem/notebook-templates/_index.md
@@ -1,0 +1,76 @@
++++
+title = 'Notebook templates'
+weight = 7
+date = 2026-08-18
+bookCollapseSection = true
++++
+
+# Notebook templates
+
+APGAP ships seven Jupyter notebooks pre-loaded into every project's Vertex AI Workbench. They cover the common paths a new user takes: getting oriented, reading data, running pipelines, pulling from external repositories, and looking up file formats and tool concepts.
+
+The notebooks live at `/home/jupyter/apgap-notebooks/notebooks/` on the Workbench. Open a notebook in JupyterLab and pick the **Python 3 (Local)** kernel from the launcher. Avoid the PyTorch, TensorFlow, and ipykernel variants; they are missing libraries these notebooks need. If you're new to the Workbench itself, start with the [Vertex AI Workbench primer](../vertex/).
+
+## At a glance
+
+| # | Notebook | What it does | Difficulty | Est. time | Launches |
+|---|---|---|---|---|---|
+| 01 | `01-getting-started` | Confirms identity, project, bucket access | Beginner | 5 min |  |
+| 02 | `02-read-your-data` | Streams FASTQs from GCS, joins metadata | Beginner | 10 min |  |
+| 03 | `03-launch-a-pipeline` | Runs nf-core/viralrecon (or any nf-core pipeline) on GCP Batch | Intermediate | 30-45 min | nf-core pipelines |
+| 04 | `04-download-from-public-repos` | Pulls sequencing data from NCBI SRA, ENA, GenBank | Beginner | 5-30 min |  |
+| 05 | `05-reference` | File-format and tool cheatsheet (markdown-only) | Beginner | 30 min reading |  |
+| 06 | `06-launch-tostadas` | Packages a consensus genome for NCBI GenBank submission | Intermediate | 15-30 min dry-run | tostadas |
+| 07 | `07-launch-basespace-copy` | Copies FASTQ files from Illumina BaseSpace | Intermediate | Varies with file size | basespace-copy |
+
+## Per-notebook detail
+
+### `01-getting-started`
+
+Your first notebook. Confirms your kernel, GCP identity, and project name, then lists the buckets visible to you. Also previews a sample of your data if a dataset is loaded. If this notebook doesn't run cleanly end-to-end, contact your Platform Admin. Everything downstream depends on the basics working.
+
+**Prereqs:** Portal account, lab membership, project with an active Workbench.
+
+### `02-read-your-data`
+
+Reads FASTQ files directly from your project's analytical-dataset bucket without downloading them locally. Uses `gcsfs` under the hood. Reports per-file stats (read count, total bases), does a paired-end sanity check, and joins to `_apgap_metadata.csv` for a per-sample view.
+
+**Prereqs:** nb 01 completed; at least one dataset loaded in the project.
+
+### `03-launch-a-pipeline`
+
+Installs Nextflow + JDK 17 (both version-pinned), writes a Google Batch configuration for your project, and runs `nf-core/viralrecon` on a small synthetic test dataset. Also includes a samplesheet builder for your own data and a commented-out real-data launch cell.
+
+The launch cells work as a template for any nf-core pipeline. Change `PIPELINE_REPO` and `PIPELINE_REVISION` in the parameter cell and the rest transfers. See the notebook's "How to use this template" section for the switching guide.
+
+**Prereqs:** nb 01 completed; project has a compute environment configured.
+
+### `04-download-from-public-repos`
+
+Pulls sequencing data from NCBI's Sequence Read Archive (SRA), its European mirror (ENA), and reference sequences from GenBank via NCBI's Entrez API. Handles the `sra-tools` install with a version pin (older builds fail TLS handshake against modern NCBI). Cross-checks that SRA and ENA copies of the same accession agree on the underlying reads. They do, though the FASTQ header conventions differ.
+
+**Prereqs:** nb 01 completed; external network access from the Workbench.
+
+### `05-reference`
+
+A markdown-only reference notebook. Covers file formats you'll see across the platform (FASTQ, FASTA, VCF, BAM, GFF, BED), tool concepts (Nextflow, nf-core, GCP Batch), samplesheet conventions, and links out to canonical documentation. No code cells to run; open it, read what you need, keep it in a tab as you work.
+
+**Prereqs:** none.
+
+### `06-launch-tostadas`
+
+Runs CDC's `tostadas` pipeline (the `feature/measles-vadr` branch, forked and patched for GCP Batch compatibility) to package an assembled consensus genome into a submission bundle for NCBI GenBank. Uses VADR for viral annotation and `table2asn` for the final `.sqn` submission file.
+
+Ships with three run modes: (1) dry-run on Glen's pre-loaded measles demo data, (2) dry-run on your own data, and (3) real submission to NCBI. Modes 1 and 2 require no NCBI credentials and produce no upstream artifacts. Mode 3 posts to NCBI's production endpoints. Read the un-comment checklist in the notebook before enabling it.
+
+**Prereqs:** nb 01 completed; consensus FASTA + metadata XLSX in a GCS bucket; NCBI account only for Mode 3.
+
+### `07-launch-basespace-copy`
+
+Copies FASTQ files from Illumina BaseSpace into an APGAP ingest bucket. From the ingest bucket, an APGAP-managed compliance cascade (DLP scan → SRA human-read scrubber) routes the files to your lab's analytical-dataset bucket. This notebook uses local Python + the `bs` CLI + `gsutil`; there is also a parallel Seqera Platform launch path that runs the same copy through a Nextflow pipeline.
+
+**Prereqs:** nb 01 completed; Illumina BaseSpace account with project access; a batch-upload endpoint created via the APGAP Portal.
+
+## Where to find the source
+
+All seven notebooks live in the public repository at [`azpathogens/apgap-notebooks`](https://github.com/azpathogens/apgap-notebooks). The copy on your Workbench is a clone that stays in sync with `main`. If you find a bug or have a suggestion, file an issue there.

--- a/content/docs/apgap_ecosystem/notebook-templates/_index.md
+++ b/content/docs/apgap_ecosystem/notebook-templates/_index.md
@@ -7,7 +7,7 @@ bookCollapseSection = true
 
 # Notebook templates
 
-APGAP ships seven Jupyter notebooks pre-loaded into every project's Vertex AI Workbench. They cover the common paths a new user takes: getting oriented, reading data, running pipelines, pulling from external repositories, and looking up file formats and tool concepts.
+APGAP ships several Jupyter notebook templates pre-loaded into every project's Vertex AI Workbench. They cover the common paths a new user takes: getting oriented, reading data, running pipelines, pulling from external repositories, and looking up file formats and tool concepts.
 
 The notebooks live at `/home/jupyter/apgap-notebooks/notebooks/` on the Workbench. Open a notebook in JupyterLab and pick the **Python 3 (Local)** kernel from the launcher. Avoid the PyTorch, TensorFlow, and ipykernel variants; they are missing libraries these notebooks need. If you're new to the Workbench itself, start with the [Vertex AI Workbench primer](../vertex/).
 
@@ -61,7 +61,7 @@ A markdown-only reference notebook. Covers file formats you'll see across the pl
 
 Runs CDC's `tostadas` pipeline (the `feature/measles-vadr` branch, forked and patched for GCP Batch compatibility) to package an assembled consensus genome into a submission bundle for NCBI GenBank. Uses VADR for viral annotation and `table2asn` for the final `.sqn` submission file.
 
-Ships with three run modes: (1) dry-run on Glen's pre-loaded measles demo data, (2) dry-run on your own data, and (3) real submission to NCBI. Modes 1 and 2 require no NCBI credentials and produce no upstream artifacts. Mode 3 posts to NCBI's production endpoints. Read the un-comment checklist in the notebook before enabling it.
+Ships with three run modes: (1) dry-run on a small measles demo dataset, (2) dry-run on your own data, and (3) real submission to NCBI. Modes 1 and 2 require no NCBI credentials and produce no upstream artifacts. Mode 3 posts to NCBI's production endpoints. Read the un-comment checklist in the notebook before enabling it.
 
 **Prereqs:** nb 01 completed; consensus FASTA + metadata XLSX in a GCS bucket; NCBI account only for Mode 3.
 
@@ -73,4 +73,4 @@ Copies FASTQ files from Illumina BaseSpace into an APGAP ingest bucket. From the
 
 ## Where to find the source
 
-All seven notebooks live in the public repository at [`azpathogens/apgap-notebooks`](https://github.com/azpathogens/apgap-notebooks). The copy on your Workbench is a clone that stays in sync with `main`. If you find a bug or have a suggestion, file an issue there.
+All the notebooks live in the public repository at [`azpathogens/apgap-notebooks`](https://github.com/azpathogens/apgap-notebooks). The copy on your Workbench is a clone of that repository with the `main` branch checked out. If there are notebook updates you can retrieve them via `git pull`. If you find a bug or have a suggestion, file an issue in the repository.

--- a/content/docs/apgap_ecosystem/prerequisites.md
+++ b/content/docs/apgap_ecosystem/prerequisites.md
@@ -36,7 +36,3 @@ For background on how APGAP and Seqera work together, see the [Seqera Platform p
 
 - **NCBI account**: only if you plan a real submission through the tostadas pipeline (dry-runs don't need one). Sign up at https://account.ncbi.nlm.nih.gov.
 - **Illumina BaseSpace account with project access**: only if you plan to pull reads from BaseSpace through the basespace-copy pipeline. The account with the source data has to explicitly share the BaseSpace project with your account.
-
-## Getting help
-
-For access issues, start with your **Platform Admin** or your **Lab Director**. For pipeline or notebook questions, contact the analytical team at ASU-KE.

--- a/content/docs/apgap_ecosystem/prerequisites.md
+++ b/content/docs/apgap_ecosystem/prerequisites.md
@@ -1,0 +1,42 @@
++++
+title = 'Before you begin'
+weight = 6
+date = 2026-08-18
++++
+
+# Before you begin
+
+Skim this checklist before your first session on APGAP. Most items are one-time setup handled by someone else on your behalf; a few require accounts on external services. You can come back and fill gaps as you need them.
+
+## APGAP Portal account
+
+You need a login on your organization's APGAP Portal. Portal accounts are created by a **Platform Admin**. Contact them to have one provisioned for you; you cannot self-register.
+
+## Lab membership
+
+Everything on APGAP is scoped to a **lab**. To browse projects, upload sequences, or open a Workbench, you need to be assigned to at least one lab. A **Platform Admin** or a **Lab Director** can add you.
+
+## Project + Vertex AI Workbench access
+
+Individual analyses live inside **projects**, which sit under a lab. Each project is provisioned with its own Google Cloud project and its own Vertex AI Workbench instance.
+
+If your lab has an existing project, you should be able to open its Workbench directly from the Portal. No separate Google Cloud login is required. If the Workbench link fails with a 403 or a blank page, contact your Platform Admin; the underlying IAM binding may still be propagating.
+
+For an overview of what the Workbench is and how the notebooks are laid out, see the [Vertex AI Workbench primer](../vertex/).
+
+## Seqera Platform workspace (only if you'll launch pipelines from the Seqera side)
+
+At project creation time, the Portal asks whether to deploy a Seqera Platform workspace alongside the project. If you check that box, the Portal provisions a workspace and a bound compute environment, both scoped to your project. You own them from that point forward.
+
+You need this if you plan to launch pipelines through the Seqera Launchpad. You can skip it for projects that only use notebook-launched Nextflow, or that don't run pipelines at all.
+
+For background on how APGAP and Seqera work together, see the [Seqera Platform primer](../seqera/).
+
+## External accounts (only if your work needs them)
+
+- **NCBI account**: only if you plan a real submission through the tostadas pipeline (dry-runs don't need one). Sign up at https://account.ncbi.nlm.nih.gov.
+- **Illumina BaseSpace account with project access**: only if you plan to pull reads from BaseSpace through the basespace-copy pipeline. The account with the source data has to explicitly share the BaseSpace project with your account.
+
+## Getting help
+
+For access issues, start with your **Platform Admin** or your **Lab Director**. For pipeline or notebook questions, contact the analytical team at ASU-KE.


### PR DESCRIPTION
Three new pages under `/docs/apgap_ecosystem/`:

- `prerequisites.md` (weight 6): checklist of accounts, memberships, and external services users need before working with APGAP.
- `notebook-templates/` (weight 7): catalog of the seven notebook templates pre-loaded on every project's Vertex AI Workbench. At-a-glance table plus per-notebook detail.
- `nextflow-caching-and-resuming.md` (weight 8): curated reference cheatsheet contributed by Glen. Links into the canonical Nextflow, Seqera, and GCP Batch docs for cache and resume behavior.

All pages cross-link to the existing primers. No changes to any existing page.